### PR TITLE
Corrige o link de direcionamento ao Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Repositório do grupo no telegram TI no Canada
 
-[Grupo Oficial no Telegram](https://t.me/ti_no_canada)
+[Grupo Oficial no Telegram](https://t.me/tinocanada)
 
 [Regras do Grupo no Telegram](https://github.com/ti-no-canada/Geral/blob/master/regras-do-grupo.md)
 


### PR DESCRIPTION
Fala pessoal, tudo bem?

Encontrei o repositório, achei bem bacana o grupo!

Porém, ao tentar entrar no Telegram tive dificuldades com o link, pois estava exibindo como não existente.
Pesquisei o novo acesso de direcionamento no telegram, e inclui nesse Pull Request. 😉👋